### PR TITLE
Implement category filter on dashboard cards

### DIFF
--- a/app/api/[[...route]]/summary.ts
+++ b/app/api/[[...route]]/summary.ts
@@ -18,11 +18,12 @@ const app = new Hono().get(
       from: z.string().optional(),
       to: z.string().optional(),
       accountId: z.string().optional(),
+      categoryId: z.string().optional(),
     })
   ),
   async (ctx) => {
     const auth = getAuth(ctx);
-    const { from, to, accountId } = ctx.req.valid("query");
+    const { from, to, accountId, categoryId } = ctx.req.valid("query");
 
     if (!auth?.userId) {
       return ctx.json({ error: "Unauthorized." }, 401);
@@ -62,6 +63,7 @@ const app = new Hono().get(
         .where(
           and(
             accountId ? eq(transactions.accountId, accountId) : undefined,
+            categoryId ? eq(transactions.categoryId, categoryId) : undefined,
             eq(accounts.userId, userId),
             gte(transactions.date, startDate),
             lte(transactions.date, endDate)
@@ -106,6 +108,7 @@ const app = new Hono().get(
       .where(
         and(
           accountId ? eq(transactions.accountId, accountId) : undefined,
+          categoryId ? eq(transactions.categoryId, categoryId) : undefined,
           eq(accounts.userId, auth.userId),
           lt(transactions.amount, 0),
           gte(transactions.date, startDate),
@@ -144,6 +147,7 @@ const app = new Hono().get(
       .where(
         and(
           accountId ? eq(transactions.accountId, accountId) : undefined,
+          categoryId ? eq(transactions.categoryId, categoryId) : undefined,
           eq(accounts.userId, auth.userId),
           gte(transactions.date, startDate),
           lte(transactions.date, endDate)

--- a/components/category-filter.tsx
+++ b/components/category-filter.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import qs from "query-string";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useGetCategories } from "@/features/categories/api/use-get-categories";
+import { useGetSummary } from "@/features/summary/api/use-get-summary";
+
+type CategoryFilterProps = {
+  className?: string;
+};
+
+export const CategoryFilter = ({ className }: CategoryFilterProps) => {
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const { isLoading: isLoadingSummary } = useGetSummary();
+
+  const categoryId = searchParams.get("categoryId") || "all";
+  const accountId = searchParams.get("accountId") || "";
+  const from = searchParams.get("from") || "";
+  const to = searchParams.get("to") || "";
+
+  const onChange = (newValue: string) => {
+    const query: Record<string, string> = {
+      accountId,
+      from,
+      to,
+      categoryId: newValue,
+    };
+
+    if (newValue === "all") delete query.categoryId;
+    if (!accountId) delete query.accountId;
+    if (!from) delete query.from;
+    if (!to) delete query.to;
+
+    const url = qs.stringifyUrl(
+      {
+        url: pathname,
+        query,
+      },
+      { skipNull: true, skipEmptyString: true }
+    );
+
+    router.push(url);
+  };
+
+  const { data: categories, isLoading: isLoadingCategories } = useGetCategories();
+
+  return (
+    <Select
+      value={categoryId}
+      onValueChange={onChange}
+      disabled={isLoadingCategories || isLoadingSummary}
+    >
+      <SelectTrigger
+        className={
+          className ||
+          "h-7 rounded-md border-none bg-white/10 px-2 text-xs font-normal text-white outline-none transition hover:bg-white/30 hover:text-white focus:bg-white/30 focus:ring-transparent focus:ring-offset-0"
+        }
+      >
+        <SelectValue placeholder="Select category" />
+      </SelectTrigger>
+
+      <SelectContent>
+        <SelectItem value="all">All categories</SelectItem>
+        {categories?.map((category) => (
+          <SelectItem key={category.id} value={category.id}>
+            {category.name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+};

--- a/components/data-grid.tsx
+++ b/components/data-grid.tsx
@@ -8,6 +8,7 @@ import { useGetSummary } from "@/features/summary/api/use-get-summary";
 import { formatDateRange } from "@/lib/utils";
 
 import { DataCard, DataCardLoading } from "./data-card";
+import { CategoryFilter } from "./category-filter";
 
 export const DataGrid = () => {
   const { data, isLoading } = useGetSummary();
@@ -37,23 +38,29 @@ export const DataGrid = () => {
         dateRange={dateRangeLabel}
       />
 
-      <DataCard
-        title="Income"
-        value={data?.incomeAmount}
-        percentageChange={data?.incomeChange}
-        icon={FaArrowTrendUp}
-        variant="success"
-        dateRange={dateRangeLabel}
-      />
+      <div className="relative">
+        <CategoryFilter className="absolute right-2 top-2 h-7 rounded-md border-none bg-white/10 px-2 text-xs font-normal text-white outline-none transition hover:bg-white/30 hover:text-white focus:bg-white/30 focus:ring-transparent focus:ring-offset-0" />
+        <DataCard
+          title="Income"
+          value={data?.incomeAmount}
+          percentageChange={data?.incomeChange}
+          icon={FaArrowTrendUp}
+          variant="success"
+          dateRange={dateRangeLabel}
+        />
+      </div>
 
-      <DataCard
-        title="Expenses"
-        value={data?.expensesAmount}
-        percentageChange={data?.expensesChange}
-        icon={FaArrowTrendDown}
-        variant="danger"
-        dateRange={dateRangeLabel}
-      />
+      <div className="relative">
+        <CategoryFilter className="absolute right-2 top-2 h-7 rounded-md border-none bg-white/10 px-2 text-xs font-normal text-white outline-none transition hover:bg-white/30 hover:text-white focus:bg-white/30 focus:ring-transparent focus:ring-offset-0" />
+        <DataCard
+          title="Expenses"
+          value={data?.expensesAmount}
+          percentageChange={data?.expensesChange}
+          icon={FaArrowTrendDown}
+          variant="danger"
+          dateRange={dateRangeLabel}
+        />
+      </div>
     </div>
   );
 };

--- a/features/summary/api/use-get-summary.ts
+++ b/features/summary/api/use-get-summary.ts
@@ -9,15 +9,17 @@ export const useGetSummary = () => {
   const from = searchParams.get("from") || "";
   const to = searchParams.get("to") || "";
   const accountId = searchParams.get("accountId") || "";
+  const categoryId = searchParams.get("categoryId") || "";
 
   const query = useQuery({
-    queryKey: ["summary", { from, to, accountId }],
+    queryKey: ["summary", { from, to, accountId, categoryId }],
     queryFn: async () => {
       const response = await client.api.summary.$get({
         query: {
           from,
           to,
           accountId,
+          categoryId,
         },
       });
 


### PR DESCRIPTION
## Summary
- introduce `CategoryFilter` component
- update summary API to accept `categoryId` query
- extend summary hook with categoryId param
- overlay category dropdowns on income and expense cards

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684413a3b800832eb899d6b40a51fa0a