### PR TITLE
Add category balance to summary view

### DIFF
--- a/app/api/[[...route]]/summary.ts
+++ b/app/api/[[...route]]/summary.ts
@@ -57,6 +57,7 @@ const app = new Hono().get(
               Number
             ),
           remaining: sum(transactions.amount).mapWith(Number),
+          categoryBalance: sql`SUM(${transactions.amount})`.mapWith(Number),
         })
         .from(transactions)
         .innerJoin(accounts, eq(transactions.accountId, accounts.id))
@@ -161,6 +162,7 @@ const app = new Hono().get(
     return ctx.json({
       data: {
         remainingAmount: currentPeriod.remaining,
+        categoryBalance: currentPeriod.categoryBalance,
         remainingChange,
         incomeAmount: currentPeriod.income,
         incomeChange,

--- a/components/data-grid.tsx
+++ b/components/data-grid.tsx
@@ -2,7 +2,7 @@
 
 import { useSearchParams } from "next/navigation";
 import { FaPiggyBank } from "react-icons/fa";
-import { FaArrowTrendUp, FaArrowTrendDown } from "react-icons/fa6";
+import { FaArrowTrendUp, FaArrowTrendDown, FaWallet } from "react-icons/fa6";
 
 import { useGetSummary } from "@/features/summary/api/use-get-summary";
 import { formatDateRange } from "@/lib/utils";
@@ -14,20 +14,24 @@ export const DataGrid = () => {
   const searchParams = useSearchParams();
   const to = searchParams.get("to") || undefined;
   const from = searchParams.get("from") || undefined;
+  const categoryId = searchParams.get("categoryId") || "all";
+
+  const gridCols = categoryId !== "all" ? "lg:grid-cols-4" : "lg:grid-cols-3";
 
   const dateRangeLabel = formatDateRange({ to, from });
 
   if (isLoading)
     return (
-      <div className="mb-8 grid grid-cols-1 gap-8 pb-2 lg:grid-cols-3">
+      <div className={`mb-8 grid grid-cols-1 gap-8 pb-2 ${gridCols}`}>
         <DataCardLoading />
+        {categoryId !== "all" && <DataCardLoading />}
         <DataCardLoading />
         <DataCardLoading />
       </div>
     );
 
   return (
-    <div className="mb-8 grid grid-cols-1 gap-8 pb-2 lg:grid-cols-3">
+    <div className={`mb-8 grid grid-cols-1 gap-8 pb-2 ${gridCols}`}>
       <DataCard
         title="Balance"
         value={data?.remainingAmount}
@@ -36,6 +40,16 @@ export const DataGrid = () => {
         variant="default"
         dateRange={dateRangeLabel}
       />
+
+      {categoryId !== "all" && (
+        <DataCard
+          title="Category Balance"
+          value={data?.categoryBalance}
+          icon={FaWallet}
+          variant="warning"
+          dateRange={dateRangeLabel}
+        />
+      )}
 
       <DataCard
         title="Total Income"

--- a/features/summary/api/use-get-summary.ts
+++ b/features/summary/api/use-get-summary.ts
@@ -32,6 +32,7 @@ export const useGetSummary = () => {
         incomeAmount: convertAmountFromMilliunits(data.incomeAmount),
         expensesAmount: convertAmountFromMilliunits(data.expensesAmount),
         remainingAmount: convertAmountFromMilliunits(data.remainingAmount),
+        categoryBalance: convertAmountFromMilliunits(data.categoryBalance),
         categories: data.categories.map((category) => ({
           ...category,
           value: convertAmountFromMilliunits(category.value),


### PR DESCRIPTION
## Summary
- extend API summary calculation with `categoryBalance`
- expose that field in summary hook
- show category balance card when a category is filtered

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68446d0e7b98832ea4d5f49571cb4b7c