### PR TITLE
Update UI language to Indonesian

### DIFF
--- a/app/(auth)/sign-in/[[...sign-in]]/page.tsx
+++ b/app/(auth)/sign-in/[[...sign-in]]/page.tsx
@@ -7,9 +7,9 @@ const SignInPage = () => {
     <div className="grid min-h-screen grid-cols-1 lg:grid-cols-2">
       <div className="h-full flex-col items-center justify-center px-4 lg:flex">
         <div className="space-y-4 pt-16 text-center">
-          <h1 className="text-3xl font-bold text-[#2E2A47]">Welcome back!</h1>
+          <h1 className="text-3xl font-bold text-[#2E2A47]">Selamat datang kembali!</h1>
           <p className="text-base text-[#7E8CA0]">
-            Log in or create account to get back to your dashboard.
+            Masuk atau buat akun untuk kembali ke dashboard Anda.
           </p>
         </div>
 

--- a/app/(auth)/sign-up/[[...sign-up]]/page.tsx
+++ b/app/(auth)/sign-up/[[...sign-up]]/page.tsx
@@ -7,9 +7,9 @@ const SignUpPage = () => {
     <div className="grid min-h-screen grid-cols-1 lg:grid-cols-2">
       <div className="h-full flex-col items-center justify-center px-4 lg:flex">
         <div className="space-y-4 pt-16 text-center">
-          <h1 className="text-3xl font-bold text-[#2E2A47]">Welcome back!</h1>
+          <h1 className="text-3xl font-bold text-[#2E2A47]">Selamat datang kembali!</h1>
           <p className="text-base text-[#7E8CA0]">
-            Log in or create account to get back to your dashboard.
+            Masuk atau buat akun untuk kembali ke dashboard Anda.
           </p>
         </div>
 

--- a/app/(dashboard)/accounts/actions.tsx
+++ b/app/(dashboard)/accounts/actions.tsx
@@ -22,8 +22,8 @@ export const Actions = ({ id }: ActionsProps) => {
   const { onOpen } = useOpenAccount();
 
   const [ConfirmDialog, confirm] = useConfirm(
-    "Are you sure?",
-    "You are about to delete this account."
+    "Apakah Anda yakin?",
+    "Anda akan menghapus akun ini."
   );
 
   const handleDelete = async () => {
@@ -50,7 +50,7 @@ export const Actions = ({ id }: ActionsProps) => {
             onClick={() => onOpen(id)}
           >
             <Edit className="mr-2 size-4" />
-            Edit
+            Ubah
           </DropdownMenuItem>
 
           <DropdownMenuItem
@@ -58,7 +58,7 @@ export const Actions = ({ id }: ActionsProps) => {
             onClick={handleDelete}
           >
             <Trash className="mr-2 size-4" />
-            Delete
+            Hapus
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/app/(dashboard)/accounts/page.tsx
+++ b/app/(dashboard)/accounts/page.tsx
@@ -42,10 +42,10 @@ const AccountsPage = () => {
     <div className="mx-auto -mt-6 w-full max-w-screen-2xl pb-10">
       <Card className="border-none drop-shadow-sm">
         <CardHeader className="gap-y-2 lg:flex-row lg:items-center lg:justify-between">
-          <CardTitle className="line-clamp-1 text-xl">Accounts Page</CardTitle>
+          <CardTitle className="line-clamp-1 text-xl">Halaman Akun</CardTitle>
 
           <Button size="sm" onClick={newAccount.onOpen}>
-            <Plus className="mr-2 size-4" /> Add new
+            <Plus className="mr-2 size-4" /> Tambah
           </Button>
         </CardHeader>
 

--- a/app/(dashboard)/categories/actions.tsx
+++ b/app/(dashboard)/categories/actions.tsx
@@ -22,8 +22,8 @@ export const Actions = ({ id }: ActionsProps) => {
   const { onOpen } = useOpenCategory();
 
   const [ConfirmDialog, confirm] = useConfirm(
-    "Are you sure?",
-    "You are about to delete this category."
+    "Apakah Anda yakin?",
+    "Anda akan menghapus kategori ini."
   );
 
   const handleDelete = async () => {
@@ -50,7 +50,7 @@ export const Actions = ({ id }: ActionsProps) => {
             onClick={() => onOpen(id)}
           >
             <Edit className="mr-2 size-4" />
-            Edit
+            Ubah
           </DropdownMenuItem>
 
           <DropdownMenuItem
@@ -58,7 +58,7 @@ export const Actions = ({ id }: ActionsProps) => {
             onClick={handleDelete}
           >
             <Trash className="mr-2 size-4" />
-            Delete
+            Hapus
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/app/(dashboard)/categories/page.tsx
+++ b/app/(dashboard)/categories/page.tsx
@@ -42,12 +42,10 @@ const CategoriesPage = () => {
     <div className="mx-auto -mt-6 w-full max-w-screen-2xl pb-10">
       <Card className="border-none drop-shadow-sm">
         <CardHeader className="gap-y-2 lg:flex-row lg:items-center lg:justify-between">
-          <CardTitle className="line-clamp-1 text-xl">
-            Categories Page
-          </CardTitle>
+          <CardTitle className="line-clamp-1 text-xl">Halaman Kategori</CardTitle>
 
           <Button size="sm" onClick={newCategory.onOpen}>
-            <Plus className="mr-2 size-4" /> Add new
+            <Plus className="mr-2 size-4" /> Tambah
           </Button>
         </CardHeader>
 

--- a/app/(dashboard)/transactions/actions.tsx
+++ b/app/(dashboard)/transactions/actions.tsx
@@ -22,8 +22,8 @@ export const Actions = ({ id }: ActionsProps) => {
   const { onOpen } = useOpenTransaction();
 
   const [ConfirmDialog, confirm] = useConfirm(
-    "Are you sure?",
-    "You are about to delete this transaction."
+    "Apakah Anda yakin?",
+    "Anda akan menghapus transaksi ini."
   );
 
   const handleDelete = async () => {
@@ -50,7 +50,7 @@ export const Actions = ({ id }: ActionsProps) => {
             onClick={() => onOpen(id)}
           >
             <Edit className="mr-2 size-4" />
-            Edit
+            Ubah
           </DropdownMenuItem>
 
           <DropdownMenuItem
@@ -58,7 +58,7 @@ export const Actions = ({ id }: ActionsProps) => {
             onClick={handleDelete}
           >
             <Trash className="mr-2 size-4" />
-            Delete
+            Hapus
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/app/(dashboard)/transactions/page.tsx
+++ b/app/(dashboard)/transactions/page.tsx
@@ -57,7 +57,7 @@ const TransactionsPage = () => {
     const accountId = await confirm();
 
     if (!accountId) {
-      return toast.error("Please select an account to continue.");
+      return toast.error("Silakan pilih akun untuk melanjutkan.");
     }
 
     const data = values.map((value) => ({
@@ -111,9 +111,7 @@ const TransactionsPage = () => {
     <div className="mx-auto -mt-6 w-full max-w-screen-2xl pb-10">
       <Card className="border-none drop-shadow-sm">
         <CardHeader className="gap-y-2 lg:flex-row lg:items-center lg:justify-between">
-          <CardTitle className="line-clamp-1 text-xl">
-            Transaction History
-          </CardTitle>
+          <CardTitle className="line-clamp-1 text-xl">Riwayat Transaksi</CardTitle>
 
           <div className="flex flex-col items-center gap-x-2 gap-y-2 lg:flex-row">
             <Button
@@ -121,7 +119,7 @@ const TransactionsPage = () => {
               onClick={newTransaction.onOpen}
               className="w-full lg:w-auto"
             >
-              <Plus className="mr-2 size-4" /> Add new
+            <Plus className="mr-2 size-4" /> Tambah
             </Button>
 
             <UploadButton onUpload={onUpload} />

--- a/app/api/[[...route]]/summary.ts
+++ b/app/api/[[...route]]/summary.ts
@@ -51,17 +51,17 @@ const app = new Hono().get(
     const lastPeriodStart = subDays(startDate, periodLength);
     const lastPeriodEnd = subDays(endDate, periodLength);
 
-    const investmentCategory = await db
-      .select({ id: categories.id })
-      .from(categories)
+    const investmentAccount = await db
+      .select({ id: accounts.id })
+      .from(accounts)
       .where(
         and(
-          orgId ? eq(categories.orgId, orgId) : eq(categories.userId, auth.userId),
-          eq(categories.name, "Investasi")
+          orgId ? eq(accounts.orgId, orgId) : eq(accounts.userId, auth.userId),
+          eq(accounts.name, "Investment")
         )
       )
       .limit(1);
-    const investmentCategoryId = investmentCategory[0]?.id;
+    const investmentAccountId = investmentAccount[0]?.id;
 
     async function fetchFinancialData(
       userId: string,
@@ -70,8 +70,8 @@ const app = new Hono().get(
     ) {
       const categoryCondition =
         isCompanyMode && !categoryId
-          ? investmentCategoryId
-            ? eq(transactions.categoryId, investmentCategoryId)
+          ? investmentAccountId
+            ? eq(transactions.accountId, investmentAccountId)
             : undefined
           : categoryId
             ? eq(transactions.categoryId, categoryId)
@@ -108,7 +108,7 @@ const app = new Hono().get(
       startDate: Date,
       endDate: Date
     ) {
-      if (!investmentCategoryId) return [{ investment: 0 }];
+      if (!investmentAccountId) return [{ investment: 0 }];
 
       return await db
         .select({
@@ -122,7 +122,7 @@ const app = new Hono().get(
         .where(
           and(
             accountCondition,
-            eq(transactions.categoryId, investmentCategoryId),
+            eq(transactions.accountId, investmentAccountId),
             orgId ? eq(accounts.orgId, orgId) : eq(accounts.userId, userId),
             gte(transactions.date, startDate),
             lte(transactions.date, endDate)
@@ -167,10 +167,10 @@ const app = new Hono().get(
       lastInvestment.investment
     );
 
-    const currentRemaining = investmentCategoryId
+    const currentRemaining = investmentAccountId
       ? currentInvestment.investment - currentPeriod.expenses
       : currentPeriod.remaining;
-    const lastRemaining = investmentCategoryId
+    const lastRemaining = investmentAccountId
       ? lastInvestment.investment - lastPeriod.expenses
       : lastPeriod.remaining;
 
@@ -230,8 +230,8 @@ const app = new Hono().get(
         and(
           accountCondition,
           isCompanyMode && !categoryId
-            ? investmentCategoryId
-              ? eq(transactions.categoryId, investmentCategoryId)
+            ? investmentAccountId
+              ? eq(transactions.accountId, investmentAccountId)
               : undefined
             : categoryId
               ? eq(transactions.categoryId, categoryId)
@@ -259,7 +259,7 @@ const app = new Hono().get(
         expensesChange,
         categories: finalCategories,
         days,
-        hasInvestmentCategory: Boolean(investmentCategoryId),
+        hasInvestmentCategory: Boolean(investmentAccountId),
       },
     });
   }

--- a/components/data-card.tsx
+++ b/components/data-card.tsx
@@ -100,8 +100,8 @@ export const DataCard = ({
               percentageChange < 0 && "text-rose-500"
             )}
           >
-            {formatPercentage(percentageChange, { addPrefix: true })} from last
-            period.
+            {formatPercentage(percentageChange, { addPrefix: true })} dari
+            periode sebelumnya.
           </p>
         </CardContent>
       </Card>

--- a/components/data-grid.tsx
+++ b/components/data-grid.tsx
@@ -45,7 +45,7 @@ export const DataGrid = () => {
     <div className={`mb-8 grid ${gridCols} gap-8 pb-2`}>
       {categoryName === "all" && (
         <DataCard
-          title="Balance"
+          title="Saldo"
           value={data?.remainingAmount}
           percentageChange={data?.remainingChange}
           icon={FaPiggyBank}
@@ -55,7 +55,7 @@ export const DataGrid = () => {
       )}
       {hasInvestment && categoryName === "all" && (
         <DataCard
-          title="Total Investment"
+          title="Total Investasi"
           value={data?.investmentAmount}
           percentageChange={data?.investmentChange}
           icon={FaCoins}
@@ -65,7 +65,7 @@ export const DataGrid = () => {
       )}
       {categoryName !== "all" && (
         <DataCard
-          title="Category Balance"
+          title="Saldo Kategori"
           value={data?.categoryBalance}
           icon={FaWallet}
           variant="warning"
@@ -74,7 +74,7 @@ export const DataGrid = () => {
       )}
       {categoryName === "Pribadi" && (
         <DataCard
-          title="Total Income"
+          title="Total Pemasukan"
           value={data?.incomeAmount}
           percentageChange={data?.incomeChange}
           icon={FaArrowTrendUp}
@@ -84,7 +84,7 @@ export const DataGrid = () => {
       )}
       {categoryName !== "Investasi" && (
         <DataCard
-          title="Total Expenses"
+          title="Total Pengeluaran"
           value={data?.expensesAmount}
           percentageChange={data?.expensesChange}
           icon={FaArrowTrendDown}

--- a/components/data-table.tsx
+++ b/components/data-table.tsx
@@ -44,8 +44,8 @@ export function DataTable<TData, TValue>({
   disabled,
 }: DataTableProps<TData, TValue>) {
   const [ConfirmDialog, confirm] = useConfirm(
-    "Are you sure?",
-    "You are about to perform a bulk delete."
+    "Apakah Anda yakin?",
+    "Anda akan menghapus banyak data."
   );
   const [sorting, setSorting] = React.useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
@@ -103,7 +103,7 @@ export function DataTable<TData, TValue>({
             }}
           >
             <Trash className="mr-2 size-4" />
-            Delete ({table.getFilteredSelectedRowModel().rows.length})
+            Hapus ({table.getFilteredSelectedRowModel().rows.length})
           </Button>
         )}
       </div>
@@ -151,7 +151,7 @@ export function DataTable<TData, TValue>({
                   colSpan={columns.length}
                   className="h-24 text-center"
                 >
-                  No results.
+                  Tidak ada hasil.
                 </TableCell>
               </TableRow>
             )}
@@ -161,8 +161,8 @@ export function DataTable<TData, TValue>({
 
       <div className="flex items-center justify-end space-x-2 py-4">
         <div className="flex-1 text-sm text-muted-foreground">
-          {table.getFilteredSelectedRowModel().rows.length} of{" "}
-          {table.getFilteredRowModel().rows.length} row(s) selected.
+          {table.getFilteredSelectedRowModel().rows.length} dari{" "}
+          {table.getFilteredRowModel().rows.length} baris dipilih.
         </div>
 
         <Button
@@ -171,7 +171,7 @@ export function DataTable<TData, TValue>({
           onClick={() => table.previousPage()}
           disabled={!table.getCanPreviousPage()}
         >
-          Previous
+          Sebelumnya
         </Button>
         <Button
           variant="outline"
@@ -179,7 +179,7 @@ export function DataTable<TData, TValue>({
           onClick={() => table.nextPage()}
           disabled={!table.getCanNextPage()}
         >
-          Next
+          Berikutnya
         </Button>
       </div>
     </div>

--- a/components/header-logo.tsx
+++ b/components/header-logo.tsx
@@ -1,10 +1,16 @@
+"use client";
+
 import Link from "next/link";
+import { useGetAccounts } from "@/features/accounts/api/use-get-accounts";
 
 export const HeaderLogo = () => {
+  const { data } = useGetAccounts();
+  const orgName = data?.[0]?.orgId ?? "MYZ Finance";
+
   return (
     <Link href="/">
       <div className="hidden items-center lg:flex">
-        <p className="ml-2.5 text-2xl font-semibold text-white">MYZ Finance</p>
+        <p className="ml-2.5 text-2xl font-semibold text-white">{orgName}</p>
       </div>
     </Link>
   );

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -13,19 +13,19 @@ import { NavButton } from "./nav-button";
 const routes = [
   {
     href: "/",
-    label: "Overview",
+    label: "Ikhtisar",
   },
   {
     href: "/transactions",
-    label: "Transactions",
+    label: "Transaksi",
   },
   {
     href: "/accounts",
-    label: "Accounts",
+    label: "Akun",
   },
   {
     href: "/categories",
-    label: "Categories",
+    label: "Kategori",
   },
 ];
 

--- a/components/welcome-msg.tsx
+++ b/components/welcome-msg.tsx
@@ -8,11 +8,11 @@ export const WelcomeMsg = () => {
   return (
     <div className="mb-4 space-y-2">
       <h2 className="text-2xl font-medium text-white lg:text-4xl">
-        Welcome back {isLoaded ? ", " : " "}
+        Selamat datang kembali{isLoaded ? ", " : " "}
         {user?.firstName} 👋
       </h2>
       <p className="text-sm text-[#89B6FD] lg:text-base">
-        This is your financial overview report.
+        Ini adalah ringkasan laporan keuangan Anda.
       </p>
     </div>
   );

--- a/drizzle/0007_fix_orgid_columns.sql
+++ b/drizzle/0007_fix_orgid_columns.sql
@@ -1,0 +1,19 @@
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'accounts' AND column_name = 'orgId'
+    ) THEN
+        ALTER TABLE "accounts" RENAME COLUMN "orgId" TO "org_id";
+    END IF;
+END$$;
+--> statement-breakpoint
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'categories' AND column_name = 'orgId'
+    ) THEN
+        ALTER TABLE "categories" RENAME COLUMN "orgId" TO "org_id";
+    END IF;
+END$$;

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,169 @@
+{
+  "id": "a46124a0-805d-4f58-bde8-6cacc38d3de5",
+  "prevId": "c1bf340e-958b-4b8c-98f6-a043392879e3",
+  "version": "6",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payee": {
+          "name": "payee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_category_id_categories_id_fk": {
+          "name": "transactions_category_id_categories_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1750346706677,
       "tag": "0006_regular_ink",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1750346706678,
+      "tag": "0007_fix_orgid_columns",
+      "breakpoints": true
     }
   ]
 }

--- a/features/accounts/components/account-form.tsx
+++ b/features/accounts/components/account-form.tsx
@@ -13,6 +13,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { Select } from "@/components/select";
 import { insertAccountSchema } from "@/db/schema";
 
 const formSchema = insertAccountSchema.pick({
@@ -63,10 +64,10 @@ export const AccountForm = ({
           disabled={disabled}
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Name</FormLabel>
+              <FormLabel>Nama</FormLabel>
 
               <FormControl>
-                <Input placeholder="e.g. Cash, Bank, Credit Card" {...field} />
+                <Input placeholder="cth. Kas, Bank, Kartu Kredit" {...field} />
               </FormControl>
 
               <FormMessage />
@@ -80,10 +81,20 @@ export const AccountForm = ({
           disabled={disabled}
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Role</FormLabel>
+              <FormLabel>Peran</FormLabel>
 
               <FormControl>
-                <Input placeholder="e.g. admin" {...field} />
+                <Select
+                  placeholder="Pilih peran"
+                  options={[
+                    { label: "Sales", value: "Sales" },
+                    { label: "Balancing", value: "Balancing" },
+                    { label: "Investment", value: "Investment" },
+                  ]}
+                  value={field.value}
+                  onChange={field.onChange}
+                  disabled={disabled}
+                />
               </FormControl>
 
               <FormMessage />
@@ -92,7 +103,7 @@ export const AccountForm = ({
         />
 
         <Button className="w-full" disabled={disabled}>
-          {id ? "Save changes" : "Create account"}
+          {id ? "Simpan perubahan" : "Buat akun"}
         </Button>
 
         {!!id && (
@@ -104,7 +115,7 @@ export const AccountForm = ({
             variant="outline"
           >
             <Trash className="mr-2 size-4" />
-            Delete account
+            Hapus akun
           </Button>
         )}
       </form>

--- a/features/accounts/components/edit-account-sheet.tsx
+++ b/features/accounts/components/edit-account-sheet.tsx
@@ -28,8 +28,8 @@ export const EditAccountSheet = () => {
   const { isOpen, onClose, id } = useOpenAccount();
 
   const [ConfirmDialog, confirm] = useConfirm(
-    "Are you sure?",
-    "You are about to delete this account."
+    "Apakah Anda yakin?",
+    "Anda akan menghapus akun ini."
   );
 
   const accountQuery = useGetAccount(id);
@@ -49,14 +49,14 @@ export const EditAccountSheet = () => {
   };
 
   const defaultValues = accountQuery.data
-    ? {
-        name: accountQuery.data.name,
-        role: accountQuery.data.role,
-      }
-    : {
-        name: "",
-        role: "default",
-      };
+      ? {
+          name: accountQuery.data.name,
+          role: accountQuery.data.role,
+        }
+      : {
+          name: "",
+          role: "Sales",
+        };
 
   const onDelete = async () => {
     const ok = await confirm();
@@ -76,9 +76,9 @@ export const EditAccountSheet = () => {
       <Sheet open={isOpen || isPending} onOpenChange={onClose}>
         <SheetContent className="space-y-4">
           <SheetHeader>
-            <SheetTitle>Edit Account</SheetTitle>
+            <SheetTitle>Edit Akun</SheetTitle>
 
-            <SheetDescription>Edit an existing account.</SheetDescription>
+            <SheetDescription>Edit akun yang sudah ada.</SheetDescription>
           </SheetHeader>
 
           {isLoading ? (

--- a/features/accounts/components/new-account-sheet.tsx
+++ b/features/accounts/components/new-account-sheet.tsx
@@ -33,24 +33,24 @@ export const NewAccountSheet = () => {
   };
 
   return (
-    <Sheet open={isOpen || mutation.isPending} onOpenChange={onClose}>
-      <SheetContent className="space-y-4">
-        <SheetHeader>
-          <SheetTitle>New Account</SheetTitle>
+      <Sheet open={isOpen || mutation.isPending} onOpenChange={onClose}>
+        <SheetContent className="space-y-4">
+          <SheetHeader>
+            <SheetTitle>Akun Baru</SheetTitle>
 
-          <SheetDescription>
-            Create a new account to track your transactions.
-          </SheetDescription>
-        </SheetHeader>
+            <SheetDescription>
+              Buat akun baru untuk melacak transaksi Anda.
+            </SheetDescription>
+          </SheetHeader>
 
-        <AccountForm
-          defaultValues={{
-            name: "",
-            role: "default",
-          }}
-          onSubmit={onSubmit}
-          disabled={mutation.isPending}
-        />
+          <AccountForm
+            defaultValues={{
+              name: "",
+              role: "Sales",
+            }}
+            onSubmit={onSubmit}
+            disabled={mutation.isPending}
+          />
       </SheetContent>
     </Sheet>
   );

--- a/features/accounts/hooks/use-select-account.tsx
+++ b/features/accounts/hooks/use-select-account.tsx
@@ -57,14 +57,14 @@ export const useSelectAccount = (): [
     <Dialog open={promise !== null} onOpenChange={handleCancel}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Select Account</DialogTitle>
+          <DialogTitle>Pilih Akun</DialogTitle>
           <DialogDescription>
-            Please select an account to continue.
+            Silakan pilih akun untuk melanjutkan.
           </DialogDescription>
         </DialogHeader>
 
         <Select
-          placeholder="Select an account"
+          placeholder="Pilih akun"
           options={accountOptions}
           onCreate={onCreateAccount}
           onChange={(value) => (selectValue.current = value)}

--- a/features/categories/components/category-form.tsx
+++ b/features/categories/components/category-form.tsx
@@ -62,10 +62,10 @@ export const CategoryForm = ({
           disabled={disabled}
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Name</FormLabel>
+              <FormLabel>Nama</FormLabel>
 
               <FormControl>
-                <Input placeholder="e.g. Food, Travel, etc." {...field} />
+                <Input placeholder="cth. Makanan, Perjalanan, dll." {...field} />
               </FormControl>
 
               <FormMessage />
@@ -74,7 +74,7 @@ export const CategoryForm = ({
         />
 
         <Button className="w-full" disabled={disabled}>
-          {id ? "Save changes" : "Create category"}
+          {id ? "Simpan perubahan" : "Buat kategori"}
         </Button>
 
         {!!id && (
@@ -86,7 +86,7 @@ export const CategoryForm = ({
             variant="outline"
           >
             <Trash className="mr-2 size-4" />
-            Delete category
+            Hapus kategori
           </Button>
         )}
       </form>

--- a/features/categories/components/edit-category-sheet.tsx
+++ b/features/categories/components/edit-category-sheet.tsx
@@ -27,8 +27,8 @@ export const EditCategorySheet = () => {
   const { isOpen, onClose, id } = useOpenCategory();
 
   const [ConfirmDialog, confirm] = useConfirm(
-    "Are you sure?",
-    "You are about to delete this category."
+    "Apakah Anda yakin?",
+    "Anda akan menghapus kategori ini."
   );
 
   const categoryQuery = useGetCategory(id);
@@ -73,9 +73,9 @@ export const EditCategorySheet = () => {
       <Sheet open={isOpen || isPending} onOpenChange={onClose}>
         <SheetContent className="space-y-4">
           <SheetHeader>
-            <SheetTitle>Edit Category</SheetTitle>
+            <SheetTitle>Edit Kategori</SheetTitle>
 
-            <SheetDescription>Edit an existing category.</SheetDescription>
+            <SheetDescription>Edit kategori yang sudah ada.</SheetDescription>
           </SheetHeader>
 
           {isLoading ? (

--- a/features/categories/components/new-category-sheet.tsx
+++ b/features/categories/components/new-category-sheet.tsx
@@ -34,13 +34,13 @@ export const NewCategorySheet = () => {
   return (
     <Sheet open={isOpen || mutation.isPending} onOpenChange={onClose}>
       <SheetContent className="space-y-4">
-        <SheetHeader>
-          <SheetTitle>New Category</SheetTitle>
+          <SheetHeader>
+            <SheetTitle>Kategori Baru</SheetTitle>
 
-          <SheetDescription>
-            Create a new category to organize your transactions.
-          </SheetDescription>
-        </SheetHeader>
+            <SheetDescription>
+              Buat kategori baru untuk mengelola transaksi Anda.
+            </SheetDescription>
+          </SheetHeader>
 
         <CategoryForm
           defaultValues={{

--- a/features/transactions/components/edit-transaction-sheet.tsx
+++ b/features/transactions/components/edit-transaction-sheet.tsx
@@ -29,8 +29,8 @@ export const EditTransactionSheet = () => {
   const { isOpen, onClose, id } = useOpenTransaction();
 
   const [ConfirmDialog, confirm] = useConfirm(
-    "Are you sure?",
-    "You are about to delete this transaction."
+    "Apakah Anda yakin?",
+    "Anda akan menghapus transaksi ini."
   );
 
   const transactionQuery = useGetTransaction(id);
@@ -112,9 +112,9 @@ export const EditTransactionSheet = () => {
       <Sheet open={isOpen || isPending} onOpenChange={onClose}>
         <SheetContent className="space-y-4">
           <SheetHeader>
-            <SheetTitle>Edit Transaction</SheetTitle>
+            <SheetTitle>Edit Transaksi</SheetTitle>
 
-            <SheetDescription>Edit an existing transaction.</SheetDescription>
+            <SheetDescription>Edit transaksi yang sudah ada.</SheetDescription>
           </SheetHeader>
 
           {isLoading ? (

--- a/features/transactions/components/new-transaction-sheet.tsx
+++ b/features/transactions/components/new-transaction-sheet.tsx
@@ -61,9 +61,9 @@ export const NewTransactionSheet = () => {
     <Sheet open={isOpen || isPending} onOpenChange={onClose}>
       <SheetContent className="space-y-4">
         <SheetHeader>
-          <SheetTitle>New Transaction</SheetTitle>
+          <SheetTitle>Transaksi Baru</SheetTitle>
 
-          <SheetDescription>Add a new transaction.</SheetDescription>
+          <SheetDescription>Tambah transaksi baru.</SheetDescription>
         </SheetHeader>
 
         {isLoading ? (

--- a/features/transactions/components/transaction-form.tsx
+++ b/features/transactions/components/transaction-form.tsx
@@ -114,7 +114,7 @@ export const TransactionForm = ({
 
               <FormControl>
                 <Select
-                  placeholder="Select an account"
+                  placeholder="Pilih akun"
                   options={accountOptions}
                   onCreate={onCreateAccount}
                   value={field.value}
@@ -138,7 +138,7 @@ export const TransactionForm = ({
 
               <FormControl>
                 <Select
-                  placeholder="Select a category"
+                  placeholder="Pilih kategori"
                   options={categoryOptions}
                   onCreate={onCreateCategory}
                   value={field.value}
@@ -179,7 +179,7 @@ export const TransactionForm = ({
           disabled={disabled}
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Amount</FormLabel>
+              <FormLabel>Jumlah</FormLabel>
 
               <FormControl>
                 <AmountInput
@@ -200,14 +200,14 @@ export const TransactionForm = ({
           disabled={disabled}
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Notes</FormLabel>
+              <FormLabel>Catatan</FormLabel>
 
               <FormControl>
                 <Textarea
                   {...field}
                   value={field.value || ""}
                   disabled={disabled}
-                  placeholder="Optional notes..."
+                  placeholder="Catatan opsional..."
                 />
               </FormControl>
 
@@ -217,7 +217,7 @@ export const TransactionForm = ({
         />
 
         <Button className="w-full" disabled={disabled}>
-          {id ? "Save changes" : "Create transaction"}
+          {id ? "Simpan perubahan" : "Buat transaksi"}
         </Button>
 
         {!!id && (
@@ -229,7 +229,7 @@ export const TransactionForm = ({
             variant="outline"
           >
             <Trash className="mr-2 size-4" />
-            Delete transaction
+            Hapus transaksi
           </Button>
         )}
       </form>

--- a/hooks/use-confirm.tsx
+++ b/hooks/use-confirm.tsx
@@ -45,9 +45,9 @@ export const useConfirm = (
 
         <DialogFooter className="pt-2">
           <Button onClick={handleCancel} variant="outline">
-            Cancel
+            Batal
           </Button>
-          <Button onClick={handleConfirm}>Confirm</Button>
+          <Button onClick={handleConfirm}>Konfirmasi</Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Summary
- localize the entire dashboard UI to Bahasa Indonesia
- show orgId account name in header logo
- add role selection with Sales, Balancing, Investment
- hide investment card unless user has an `Investment` account
- add safe migration to rename `orgId` to `org_id` if needed

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685cf8179ec4832eab15a8a6344c149d