### PR TITLE
Update investment calculations and org-based data

### DIFF
--- a/app/api/[[...route]]/accounts.ts
+++ b/app/api/[[...route]]/accounts.ts
@@ -12,9 +12,8 @@ const app = new Hono()
   .get("/", clerkMiddleware(), async (ctx) => {
     const auth = getAuth(ctx);
     const orgId = auth?.orgId;
-    console.log('auth org: ', orgId)
 
-    if (!auth?.userId) {
+    if (!auth?.userId || !orgId) {
       return ctx.json({ error: "Unauthorized." }, 401);
     }
 
@@ -25,7 +24,7 @@ const app = new Hono()
         role: accounts.role,
       })
       .from(accounts)
-      .where(orgId ? eq(accounts.orgId, orgId) : eq(accounts.userId, auth.userId));
+      .where(eq(accounts.orgId, orgId));
 
     return ctx.json({ data });
   })
@@ -59,10 +58,7 @@ const app = new Hono()
         })
         .from(accounts)
         .where(
-          and(
-            eq(accounts.id, id),
-            orgId ? eq(accounts.orgId, orgId) : eq(accounts.userId, auth.userId)
-          )
+          and(eq(accounts.id, id), eq(accounts.orgId, orgId))
         );
 
       if (!data) {
@@ -127,12 +123,7 @@ const app = new Hono()
 
       const data = await db
         .delete(accounts)
-        .where(
-          and(
-            (orgId ? eq(accounts.orgId, orgId) : eq(accounts.userId, auth.userId)),
-            inArray(accounts.id, values.ids)
-          )
-        )
+        .where(and(eq(accounts.orgId, orgId), inArray(accounts.id, values.ids)))
         .returning({
           id: accounts.id,
         });
@@ -173,12 +164,7 @@ const app = new Hono()
       const [data] = await db
         .update(accounts)
         .set(values)
-        .where(
-          and(
-            (orgId ? eq(accounts.orgId, orgId) : eq(accounts.userId, auth.userId)),
-            eq(accounts.id, id)
-          )
-        )
+        .where(and(eq(accounts.orgId, orgId), eq(accounts.id, id)))
         .returning();
 
       if (!data) {
@@ -212,12 +198,7 @@ const app = new Hono()
 
       const [data] = await db
         .delete(accounts)
-        .where(
-          and(
-            (orgId ? eq(accounts.orgId, orgId) : eq(accounts.userId, auth.userId)),
-            eq(accounts.id, id)
-          )
-        )
+        .where(and(eq(accounts.orgId, orgId), eq(accounts.id, id)))
         .returning({
           id: accounts.id,
         });

--- a/app/api/[[...route]]/accounts.ts
+++ b/app/api/[[...route]]/accounts.ts
@@ -13,7 +13,7 @@ const app = new Hono()
     const auth = getAuth(ctx);
     const orgId = auth?.orgId;
 
-    if (!auth?.userId || !orgId) {
+    if (!auth?.userId) {
       return ctx.json({ error: "Unauthorized." }, 401);
     }
 
@@ -24,7 +24,7 @@ const app = new Hono()
         role: accounts.role,
       })
       .from(accounts)
-      .where(eq(accounts.orgId, orgId));
+      .where(orgId ? eq(accounts.orgId, orgId) : eq(accounts.userId, auth.userId));
 
     return ctx.json({ data });
   })
@@ -58,7 +58,10 @@ const app = new Hono()
         })
         .from(accounts)
         .where(
-          and(eq(accounts.id, id), eq(accounts.orgId, orgId))
+          and(
+            eq(accounts.id, id),
+            orgId ? eq(accounts.orgId, orgId) : eq(accounts.userId, auth.userId)
+          )
         );
 
       if (!data) {
@@ -123,7 +126,12 @@ const app = new Hono()
 
       const data = await db
         .delete(accounts)
-        .where(and(eq(accounts.orgId, orgId), inArray(accounts.id, values.ids)))
+        .where(
+          and(
+            orgId ? eq(accounts.orgId, orgId) : eq(accounts.userId, auth.userId),
+            inArray(accounts.id, values.ids)
+          )
+        )
         .returning({
           id: accounts.id,
         });
@@ -164,7 +172,12 @@ const app = new Hono()
       const [data] = await db
         .update(accounts)
         .set(values)
-        .where(and(eq(accounts.orgId, orgId), eq(accounts.id, id)))
+        .where(
+          and(
+            orgId ? eq(accounts.orgId, orgId) : eq(accounts.userId, auth.userId),
+            eq(accounts.id, id)
+          )
+        )
         .returning();
 
       if (!data) {
@@ -198,7 +211,12 @@ const app = new Hono()
 
       const [data] = await db
         .delete(accounts)
-        .where(and(eq(accounts.orgId, orgId), eq(accounts.id, id)))
+        .where(
+          and(
+            orgId ? eq(accounts.orgId, orgId) : eq(accounts.userId, auth.userId),
+            eq(accounts.id, id)
+          )
+        )
         .returning({
           id: accounts.id,
         });

--- a/app/api/[[...route]]/categories.ts
+++ b/app/api/[[...route]]/categories.ts
@@ -13,7 +13,7 @@ const app = new Hono()
     const auth = getAuth(ctx);
     const orgId = auth?.orgId;
 
-    if (!auth?.userId || !orgId) {
+    if (!auth?.userId) {
       return ctx.json({ error: "Unauthorized." }, 401);
     }
 
@@ -23,7 +23,9 @@ const app = new Hono()
         name: categories.name,
       })
       .from(categories)
-      .where(eq(categories.orgId, orgId));
+      .where(
+        orgId ? eq(categories.orgId, orgId) : eq(categories.userId, auth.userId)
+      );
 
     return ctx.json({ data });
   })
@@ -55,7 +57,12 @@ const app = new Hono()
           name: categories.name,
         })
         .from(categories)
-        .where(and(eq(categories.id, id), eq(categories.orgId, orgId)));
+        .where(
+          and(
+            eq(categories.id, id),
+            orgId ? eq(categories.orgId, orgId) : eq(categories.userId, auth.userId)
+          )
+        );
 
       if (!data) {
         return ctx.json({ error: "Not found." }, 404);
@@ -115,7 +122,12 @@ const app = new Hono()
 
       const data = await db
         .delete(categories)
-        .where(and(eq(categories.orgId, orgId), inArray(categories.id, values.ids)))
+        .where(
+          and(
+            orgId ? eq(categories.orgId, orgId) : eq(categories.userId, auth.userId),
+            inArray(categories.id, values.ids)
+          )
+        )
         .returning({
           id: categories.id,
         });
@@ -155,7 +167,12 @@ const app = new Hono()
       const [data] = await db
         .update(categories)
         .set(values)
-        .where(and(eq(categories.orgId, orgId), eq(categories.id, id)))
+        .where(
+          and(
+            orgId ? eq(categories.orgId, orgId) : eq(categories.userId, auth.userId),
+            eq(categories.id, id)
+          )
+        )
         .returning();
 
       if (!data) {
@@ -189,7 +206,12 @@ const app = new Hono()
 
       const [data] = await db
         .delete(categories)
-        .where(and(eq(categories.orgId, orgId), eq(categories.id, id)))
+        .where(
+          and(
+            orgId ? eq(categories.orgId, orgId) : eq(categories.userId, auth.userId),
+            eq(categories.id, id)
+          )
+        )
         .returning({
           id: categories.id,
         });

--- a/app/api/[[...route]]/categories.ts
+++ b/app/api/[[...route]]/categories.ts
@@ -13,7 +13,7 @@ const app = new Hono()
     const auth = getAuth(ctx);
     const orgId = auth?.orgId;
 
-    if (!auth?.userId) {
+    if (!auth?.userId || !orgId) {
       return ctx.json({ error: "Unauthorized." }, 401);
     }
 
@@ -23,7 +23,7 @@ const app = new Hono()
         name: categories.name,
       })
       .from(categories)
-      .where(orgId ? eq(categories.orgId, orgId) : eq(categories.userId, auth.userId));
+      .where(eq(categories.orgId, orgId));
 
     return ctx.json({ data });
   })
@@ -55,12 +55,7 @@ const app = new Hono()
           name: categories.name,
         })
         .from(categories)
-        .where(
-          and(
-            eq(categories.id, id),
-            orgId ? eq(categories.orgId, orgId) : eq(categories.userId, auth.userId)
-          )
-        );
+        .where(and(eq(categories.id, id), eq(categories.orgId, orgId)));
 
       if (!data) {
         return ctx.json({ error: "Not found." }, 404);
@@ -120,12 +115,7 @@ const app = new Hono()
 
       const data = await db
         .delete(categories)
-        .where(
-          and(
-            orgId ? eq(categories.orgId, orgId) : eq(categories.userId, auth.userId),
-            inArray(categories.id, values.ids)
-          )
-        )
+        .where(and(eq(categories.orgId, orgId), inArray(categories.id, values.ids)))
         .returning({
           id: categories.id,
         });
@@ -165,12 +155,7 @@ const app = new Hono()
       const [data] = await db
         .update(categories)
         .set(values)
-        .where(
-          and(
-            (orgId ? eq(categories.orgId, orgId) : eq(categories.userId, auth.userId)),
-            eq(categories.id, id)
-          )
-        )
+        .where(and(eq(categories.orgId, orgId), eq(categories.id, id)))
         .returning();
 
       if (!data) {
@@ -204,12 +189,7 @@ const app = new Hono()
 
       const [data] = await db
         .delete(categories)
-        .where(
-          and(
-            (orgId ? eq(categories.orgId, orgId) : eq(categories.userId, auth.userId)),
-            eq(categories.id, id)
-          )
-        )
+        .where(and(eq(categories.orgId, orgId), eq(categories.id, id)))
         .returning({
           id: categories.id,
         });

--- a/app/api/[[...route]]/transactions.ts
+++ b/app/api/[[...route]]/transactions.ts
@@ -32,7 +32,7 @@ const app = new Hono()
       const { from, to, accountId, categoryId } = ctx.req.valid("query");
       const orgId = auth?.orgId;
 
-      if (!auth?.userId) {
+      if (!auth?.userId || !orgId) {
         return ctx.json({ error: "Unauthorized." }, 401);
       }
 
@@ -66,7 +66,7 @@ const app = new Hono()
           and(
             accountCondition,
             categoryId ? eq(transactions.categoryId, categoryId) : undefined,
-            orgId ? eq(accounts.orgId, orgId) : eq(accounts.userId, auth.userId),
+            eq(accounts.orgId, orgId),
             startDate ? gte(transactions.date, startDate) : undefined,
             endDate ? lte(transactions.date, endDate) : undefined
           )
@@ -94,7 +94,7 @@ const app = new Hono()
         return ctx.json({ error: "Missing id." }, 400);
       }
 
-      if (!auth?.userId) {
+      if (!auth?.userId || !orgId) {
         return ctx.json({ error: "Unauthorized." }, 401);
       }
 
@@ -110,12 +110,7 @@ const app = new Hono()
         })
         .from(transactions)
         .innerJoin(accounts, eq(transactions.accountId, accounts.id))
-        .where(
-          and(
-            eq(transactions.id, id),
-            orgId ? eq(accounts.orgId, orgId) : eq(accounts.userId, auth.userId)
-          )
-        );
+        .where(and(eq(transactions.id, id), eq(accounts.orgId, orgId)));
 
       if (!data) {
         return ctx.json({ error: "Not found." }, 404);
@@ -138,7 +133,7 @@ const app = new Hono()
       const values = ctx.req.valid("json");
       const orgId = auth?.orgId;
 
-      if (!auth?.userId) {
+      if (!auth?.userId || !orgId) {
         return ctx.json({ error: "Unauthorized." }, 401);
       }
 
@@ -160,8 +155,9 @@ const app = new Hono()
     async (ctx) => {
       const auth = getAuth(ctx);
       const values = ctx.req.valid("json");
+      const orgId = auth?.orgId;
 
-      if (!auth?.userId) {
+      if (!auth?.userId || !orgId) {
         return ctx.json({ error: "Unauthorized." }, 401);
       }
 
@@ -190,9 +186,9 @@ const app = new Hono()
     async (ctx) => {
       const auth = getAuth(ctx);
       const values = ctx.req.valid("json");
-        const orgId = auth?.orgId;
+      const orgId = auth?.orgId;
 
-      if (!auth?.userId) {
+      if (!auth?.userId || !orgId) {
         return ctx.json({ error: "Unauthorized." }, 401);
       }
 
@@ -204,7 +200,7 @@ const app = new Hono()
           .where(
             and(
               inArray(transactions.id, values.ids),
-              orgId ? eq(accounts.orgId, orgId) : eq(accounts.userId, auth.userId)
+              eq(accounts.orgId, orgId)
             )
           )
       );
@@ -250,7 +246,7 @@ const app = new Hono()
         return ctx.json({ error: "Missing id." }, 400);
       }
 
-      if (!auth?.userId) {
+      if (!auth?.userId || !orgId) {
         return ctx.json({ error: "Unauthorized." }, 401);
       }
 
@@ -260,10 +256,7 @@ const app = new Hono()
           .from(transactions)
           .innerJoin(accounts, eq(transactions.accountId, accounts.id))
           .where(
-            and(
-              eq(transactions.id, id),
-              orgId ? eq(accounts.orgId, orgId) : eq(accounts.userId, auth.userId)
-            )
+            and(eq(transactions.id, id), eq(accounts.orgId, orgId))
           )
       );
 
@@ -298,13 +291,13 @@ const app = new Hono()
     async (ctx) => {
       const auth = getAuth(ctx);
       const { id } = ctx.req.valid("param");
-        const orgId = auth?.orgId;
+      const orgId = auth?.orgId;
 
       if (!id) {
         return ctx.json({ error: "Missing id." }, 400);
       }
 
-      if (!auth?.userId) {
+      if (!auth?.userId || !orgId) {
         return ctx.json({ error: "Unauthorized." }, 401);
       }
 
@@ -313,12 +306,7 @@ const app = new Hono()
           .select({ id: transactions.id })
           .from(transactions)
           .innerJoin(accounts, eq(transactions.accountId, accounts.id))
-          .where(
-            and(
-              eq(transactions.id, id),
-              orgId ? eq(accounts.orgId, orgId) : eq(accounts.userId, auth.userId)
-            )
-          )
+          .where(and(eq(transactions.id, id), eq(accounts.orgId, orgId)))
       );
 
       const [data] = await db

--- a/components/data-grid.tsx
+++ b/components/data-grid.tsx
@@ -16,11 +16,12 @@ export const DataGrid = () => {
   const from = searchParams.get("from") || undefined;
   const categoryId = searchParams.get("categoryId") || "all";
   const categoryName = searchParams.get("categoryName") || "all";
-  const hasInvestment = data?.hasInvestmentCategory;
+  const hasInvestmentCategory = data?.hasInvestmentCategory;
+  const hasInvestmentAccount = data?.hasInvestmentAccount;
 
   let cardCount = 0;
   if (categoryName === "all") cardCount++; // Balance
-  if (hasInvestment && categoryName === "all") cardCount++; // Total Investment
+  if (hasInvestmentCategory && categoryName === "all") cardCount++; // Total Investment
   if (categoryName !== "all") cardCount++; // Category Balance
   if (categoryName === "Pribadi") cardCount++; // Total Income
   if (categoryName !== "Investasi") cardCount++; // Total Expenses
@@ -45,7 +46,7 @@ export const DataGrid = () => {
     <div className={`mb-8 grid ${gridCols} gap-8 pb-2`}>
       {categoryName === "all" && (
         <DataCard
-          title="Saldo"
+          title={hasInvestmentAccount ? "Sisa Saldo Investasi" : "Saldo"}
           value={data?.remainingAmount}
           percentageChange={data?.remainingChange}
           icon={FaPiggyBank}
@@ -53,7 +54,7 @@ export const DataGrid = () => {
           dateRange={dateRangeLabel}
         />
       )}
-      {hasInvestment && categoryName === "all" && (
+      {hasInvestmentCategory && categoryName === "all" && (
         <DataCard
           title="Total Investasi"
           value={data?.investmentAmount}

--- a/features/summary/api/use-get-summary.ts
+++ b/features/summary/api/use-get-summary.ts
@@ -40,6 +40,7 @@ export const useGetSummary = () => {
         investmentChange: data.investmentChange,
         categoryBalance: convertAmountFromMilliunits(data.categoryBalance),
         hasInvestmentCategory: data.hasInvestmentCategory,
+        hasInvestmentAccount: data.hasInvestmentAccount,
         categories: data.categories.map((category) => ({
           ...category,
           value: convertAmountFromMilliunits(category.value),


### PR DESCRIPTION
## Summary
- base account, category, and transaction API queries on organization ID
- compute total investment using `Investasi` category instead of investment account
- expose `hasInvestmentAccount` and fix summary calculations
- rename balance label when investment account present

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685d2c6bba44832e89308799abcd956e