### PR TITLE
Fix org switch data refresh

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import { Toaster } from "@/components/ui/sonner";
 import { siteConfig } from "@/config";
 import { QueryProviders } from "@/providers/query-provider";
 import { SheetProvider } from "@/providers/sheet-provider";
+import { OrganizationQueryListener } from "@/providers/organization-query-listener";
 
 import "./globals.css";
 
@@ -21,6 +22,7 @@ const RootLayout = ({ children }: Readonly<PropsWithChildren>) => {
       <html lang="en">
         <body className="font-sans">
           <QueryProviders>
+            <OrganizationQueryListener />
             <SheetProvider />
             <Toaster richColors theme="light" />
 

--- a/providers/organization-query-listener.tsx
+++ b/providers/organization-query-listener.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useOrganization } from "@clerk/nextjs";
+import { useQueryClient } from "@tanstack/react-query";
+
+export const OrganizationQueryListener = () => {
+  const { organization } = useOrganization();
+  const queryClient = useQueryClient();
+
+  // track previous organization id to detect changes
+  const prevOrgIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const currentOrgId = organization?.id ?? null;
+    if (prevOrgIdRef.current !== null && prevOrgIdRef.current !== currentOrgId) {
+      // invalidate all queries so data is refetched for the new organization
+      queryClient.invalidateQueries();
+    }
+    prevOrgIdRef.current = currentOrgId;
+  }, [organization?.id, queryClient]);
+
+  return null;
+};


### PR DESCRIPTION
## Summary
- add `OrganizationQueryListener` to invalidate queries when active org changes
- mount organization listener in root layout so data refreshes automatically

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685d36854fec832e9f34cd302171f3a4