### PR TITLE
Handle org changes for transaction queries

### DIFF
--- a/features/summary/api/use-get-summary.ts
+++ b/features/summary/api/use-get-summary.ts
@@ -1,10 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
 import { useSearchParams } from "next/navigation";
+import { useOrganization } from "@clerk/nextjs";
 
 import { client } from "@/lib/hono";
 import { convertAmountFromMilliunits } from "@/lib/utils";
 
 export const useGetSummary = () => {
+  const { organization } = useOrganization();
+  const orgId = organization?.id;
   const searchParams = useSearchParams();
   const from = searchParams.get("from") || "";
   const to = searchParams.get("to") || "";
@@ -13,7 +16,7 @@ export const useGetSummary = () => {
   const companyMode = searchParams.get("companyMode") || "";
 
   const query = useQuery({
-    queryKey: ["summary", { from, to, accountId, categoryId, companyMode }],
+    queryKey: ["summary", orgId, { from, to, accountId, categoryId, companyMode }],
     queryFn: async () => {
       const response = await client.api.summary.$get({
         query: {

--- a/features/transactions/api/use-get-transactions.ts
+++ b/features/transactions/api/use-get-transactions.ts
@@ -1,10 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
 import { useSearchParams } from "next/navigation";
+import { useOrganization } from "@clerk/nextjs";
 
 import { client } from "@/lib/hono";
 import { convertAmountFromMilliunits } from "@/lib/utils";
 
 export const useGetTransactions = () => {
+  const { organization } = useOrganization();
+  const orgId = organization?.id;
   const searchParams = useSearchParams();
   const from = searchParams.get("from") || "";
   const to = searchParams.get("to") || "";
@@ -12,7 +15,7 @@ export const useGetTransactions = () => {
   const categoryId = searchParams.get("categoryId") || "";
 
   const query = useQuery({
-    queryKey: ["transactions", { from, to, accountId, categoryId }],
+    queryKey: ["transactions", orgId, { from, to, accountId, categoryId }],
     queryFn: async () => {
       const response = await client.api.transactions.$get({
         query: {


### PR DESCRIPTION
## Summary
- include the current organization ID in the transactions query key
- include the current organization ID in the summary query key

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685d43827c98832eb2d4f393a8444ba4