### PR TITLE
Add public token access for transaction API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,6 @@ DATABASE_URL=postgresql://<username>:<password>@<hostname>/<database>?sslmode=re
 
 # app base url
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# public API token
+API_PUBLIC_TOKEN=your_public_token_here

--- a/app/api/[[...route]]/transactions.ts
+++ b/app/api/[[...route]]/transactions.ts
@@ -3,7 +3,7 @@ import { zValidator } from "@hono/zod-validator";
 import { createId } from "@paralleldrive/cuid2";
 import { parse } from "date-fns";
 import { and, desc, eq, gte, inArray, lte, sql } from "drizzle-orm";
-import { Hono } from "hono";
+import { Hono, type MiddlewareHandler } from "hono";
 import { z } from "zod";
 
 import { db } from "@/db/drizzle";
@@ -13,6 +13,18 @@ import {
   insertTransactionSchema,
   transactions,
 } from "@/db/schema";
+
+const clerkMw = clerkMiddleware();
+
+const publicTokenAuth: MiddlewareHandler = async (c, next) => {
+  const token = c.req.header("x-api-token");
+  if (token && token === process.env.API_PUBLIC_TOKEN) {
+    c.set("isPublic", true);
+    await next();
+  } else {
+    await clerkMw(c, next);
+  }
+};
 
 const app = new Hono()
   .get(
@@ -26,13 +38,14 @@ const app = new Hono()
         categoryId: z.string().optional(),
       })
     ),
-    clerkMiddleware(),
+    publicTokenAuth,
     async (ctx) => {
       const auth = getAuth(ctx);
+      const isPublic = ctx.get("isPublic" as never) as boolean | undefined;
       const { from, to, accountId, categoryId } = ctx.req.valid("query");
       const orgId = auth?.orgId;
 
-      if (!auth?.userId) {
+      if (!isPublic && !auth?.userId) {
         return ctx.json({ error: "Unauthorized." }, 401);
       }
 
@@ -41,8 +54,11 @@ const app = new Hono()
         : undefined;
       const endDate = to ? parse(to, "yyyy-MM-dd", new Date()) : undefined;
 
-      const userOrgCondition =
-        orgId ? eq(accounts.orgId, orgId) : eq(accounts.userId, auth.userId);
+      const userOrgCondition = isPublic
+        ? undefined
+        : orgId
+        ? eq(accounts.orgId, orgId)
+        : eq(accounts.userId, auth!.userId as string);
 
       const accountCondition = accountId
         ? eq(transactions.accountId, accountId)
@@ -85,9 +101,10 @@ const app = new Hono()
         id: z.string().optional(),
       })
     ),
-    clerkMiddleware(),
+    publicTokenAuth,
     async (ctx) => {
       const auth = getAuth(ctx);
+      const isPublic = ctx.get("isPublic" as never) as boolean | undefined;
       const { id } = ctx.req.valid("param");
       const orgId = auth?.orgId;
 
@@ -95,7 +112,7 @@ const app = new Hono()
         return ctx.json({ error: "Missing id." }, 400);
       }
 
-      if (!auth?.userId) {
+      if (!isPublic && !auth?.userId) {
         return ctx.json({ error: "Unauthorized." }, 401);
       }
 
@@ -114,7 +131,11 @@ const app = new Hono()
         .where(
           and(
             eq(transactions.id, id),
-            orgId ? eq(accounts.orgId, orgId) : eq(accounts.userId, auth.userId)
+            isPublic
+              ? undefined
+              : orgId
+              ? eq(accounts.orgId, orgId)
+              : eq(accounts.userId, auth!.userId as string)
           )
         );
 

--- a/environment.d.ts
+++ b/environment.d.ts
@@ -8,6 +8,9 @@ declare global {
 
       // app base url
       NEXT_PUBLIC_APP_URL: string;
+
+      // public api token
+      API_PUBLIC_TOKEN: string;
     }
   }
 }


### PR DESCRIPTION
## Summary
- allow a public API token for transaction endpoints
- document new `API_PUBLIC_TOKEN` environment variable

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687627819bf4832e99a1d2cbd318f9cb