### PR TITLE
Add Sales summary card

### DIFF
--- a/components/data-grid.tsx
+++ b/components/data-grid.tsx
@@ -18,13 +18,20 @@ export const DataGrid = () => {
   const categoryName = searchParams.get("categoryName") || "all";
   const hasInvestmentCategory = data?.hasInvestmentCategory;
   const hasInvestmentAccount = data?.hasInvestmentAccount;
+  const hasSalesCategory = data?.hasSalesCategory;
+  const accountRole = data?.accountRole;
 
   let cardCount = 0;
-  if (categoryName === "all") cardCount++; // Balance
-  if (hasInvestmentCategory && categoryName === "all") cardCount++; // Total Investment
-  if (categoryName !== "all") cardCount++; // Category Balance
-  if (categoryName === "Pribadi") cardCount++; // Total Income
-  if (categoryName !== "Investasi") cardCount++; // Total Expenses
+  if (accountRole === "Sales") {
+    cardCount = hasSalesCategory ? 1 : 0;
+  } else {
+    if (categoryName === "all") cardCount++; // Balance
+    if (hasInvestmentCategory && categoryName === "all") cardCount++; // Total Investment
+    if (hasSalesCategory && categoryName === "all" && accountRole !== "Investment") cardCount++; // Total Sales
+    if (categoryName !== "all") cardCount++; // Category Balance
+    if (categoryName === "Pribadi") cardCount++; // Total Income
+    if (categoryName !== "Investasi") cardCount++; // Total Expenses
+  }
 
 
   // Atur grid cols sesuai jumlah card
@@ -44,7 +51,7 @@ export const DataGrid = () => {
 
   return (
     <div className={`mb-8 grid ${gridCols} gap-8 pb-2`}>
-      {categoryName === "all" && (
+      {categoryName === "all" && accountRole !== "Sales" && (
         <DataCard
           title={hasInvestmentAccount ? "Sisa Saldo Investasi" : "Saldo"}
           value={data?.remainingAmount}
@@ -54,7 +61,7 @@ export const DataGrid = () => {
           dateRange={dateRangeLabel}
         />
       )}
-      {hasInvestmentCategory && categoryName === "all" && (
+      {hasInvestmentCategory && categoryName === "all" && accountRole !== "Sales" && (
         <DataCard
           title="Total Investasi"
           value={data?.investmentAmount}
@@ -64,7 +71,17 @@ export const DataGrid = () => {
           dateRange={dateRangeLabel}
         />
       )}
-      {categoryName !== "all" && (
+      {hasSalesCategory && categoryName === "all" && accountRole !== "Investment" && (
+        <DataCard
+          title="Total Penjualan"
+          value={data?.salesAmount}
+          percentageChange={data?.salesChange}
+          icon={FaArrowTrendUp}
+          variant="success"
+          dateRange={dateRangeLabel}
+        />
+      )}
+      {categoryName !== "all" && accountRole !== "Sales" && (
         <DataCard
           title="Saldo Kategori"
           value={data?.categoryBalance}
@@ -73,7 +90,7 @@ export const DataGrid = () => {
           dateRange={dateRangeLabel}
         />
       )}
-      {categoryName === "Pribadi" && (
+      {categoryName === "Pribadi" && accountRole !== "Sales" && (
         <DataCard
           title="Total Pemasukan"
           value={data?.incomeAmount}
@@ -83,7 +100,7 @@ export const DataGrid = () => {
           dateRange={dateRangeLabel}
         />
       )}
-      {categoryName !== "Investasi" && (
+      {categoryName !== "Investasi" && accountRole !== "Sales" && (
         <DataCard
           title="Total Pengeluaran"
           value={data?.expensesAmount}

--- a/features/summary/api/use-get-summary.ts
+++ b/features/summary/api/use-get-summary.ts
@@ -44,6 +44,10 @@ export const useGetSummary = () => {
         categoryBalance: convertAmountFromMilliunits(data.categoryBalance),
         hasInvestmentCategory: data.hasInvestmentCategory,
         hasInvestmentAccount: data.hasInvestmentAccount,
+        salesAmount: convertAmountFromMilliunits(data.salesAmount ?? 0),
+        salesChange: data.salesChange,
+        hasSalesCategory: data.hasSalesCategory,
+        accountRole: data.accountRole,
         categories: data.categories.map((category) => ({
           ...category,
           value: convertAmountFromMilliunits(category.value),


### PR DESCRIPTION
## Summary
- extend summary API to return sales data and account role
- expose new fields via useGetSummary hook
- render sales card and adjust card logic in DataGrid

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6879f75d09d8832e91f910c09cc6a62a