### PR TITLE
Switch to Business Dashboard styling

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-# Code of Conduct - Finance
+# Code of Conduct - Business Dashboard
 
 ## Our Pledge
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <!-- omit in toc -->
-# Contributing to Finance
+# Contributing to Business Dashboard
 
 First off, thanks for taking the time to contribute! ❤️
 
@@ -28,7 +28,7 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 ## Code of Conduct
 
 This project and everyone participating in it is governed by the
-[Finance Code of Conduct](https://github.com/sanidhyy/finance-dashboardblob/master/CODE_OF_CONDUCT.md).
+[Business Dashboard Code of Conduct](https://github.com/sanidhyy/finance-dashboardblob/master/CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code. Please report unacceptable behavior
 to .
 
@@ -89,7 +89,7 @@ Once it's filed:
 
 ### Suggesting Enhancements
 
-This section guides you through submitting an enhancement suggestion for Finance, **including completely new features and minor improvements to existing functionality**. Following these guidelines will help maintainers and the community to understand your suggestion and find related suggestions.
+This section guides you through submitting an enhancement suggestion for Business Dashboard, **including completely new features and minor improvements to existing functionality**. Following these guidelines will help maintainers and the community to understand your suggestion and find related suggestions.
 
 <!-- omit in toc -->
 #### Before Submitting an Enhancement
@@ -108,7 +108,7 @@ Enhancement suggestions are tracked as [GitHub issues](https://github.com/sanidh
 - Provide a **step-by-step description of the suggested enhancement** in as many details as possible.
 - **Describe the current behavior** and **explain which behavior you expected to see instead** and why. At this point you can also tell which alternatives do not work for you.
 - You may want to **include screenshots and animated GIFs** which help you demonstrate the steps or point out the part which the suggestion is related to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux. <!-- this should only be included if the project has a GUI -->
-- **Explain why this enhancement would be useful** to most Finance users. You may also want to point out the other projects that solved it better and which could serve as inspiration.
+- **Explain why this enhancement would be useful** to most Business Dashboard users. You may also want to point out the other projects that solved it better and which could serve as inspiration.
 
 <!-- omit in toc -->
 ## Attribution

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <a name="readme-top"></a>
 
-# Track your income and expenses with Finance.
+# Manage your business with Business Dashboard.
 
-![Track your income and expenses with Finance.](/.github/images/img_main.png "Track your income and expenses with Finance.")
+![Manage your business with Business Dashboard.](/.github/images/img_main.png "Manage your business with Business Dashboard.")
 
 [![Ask Me Anything!](https://flat.badgen.net/static/Ask%20me/anything?icon=github&color=black&scale=1.01)](https://github.com/sanidhyy "Ask Me Anything!")
 [![GitHub license](https://flat.badgen.net/github/license/sanidhyy/finance-dashboard?icon=github&color=black&scale=1.01)](https://github.com/sanidhyy/finance-dashboard/blob/main/LICENSE "GitHub license")
@@ -281,7 +281,7 @@ Untuk tiga endpoint transaksi (`GET /api/transactions`, `GET /api/transactions/:
 
 ## :wrench: Stats
 
-[![Stats for Finance](/.github/images/stats.svg "Stats for Finance")](https://pagespeed.web.dev/analysis?url=https://appfinance.vercel.app/ "Stats for Finance")
+[![Stats for Business Dashboard](/.github/images/stats.svg "Stats for Business Dashboard")](https://pagespeed.web.dev/analysis?url=https://appfinance.vercel.app/ "Stats for Business Dashboard")
 
 ## :raised_hands: Contribute
 
@@ -289,7 +289,7 @@ You might encounter some bugs while using this app. You are more than welcome to
 
 ## :gem: Acknowledgements
 
-Useful resources and dependencies that are used in Finance.
+Useful resources and dependencies that are used in Business Dashboard.
 
 - Thanks to CodeWithAntonio: https://codewithantonio.com/
 - [@clerk/backend](https://www.npmjs.com/package/@clerk/backend): ^1.1.3

--- a/app/(auth)/sign-in/[[...sign-in]]/page.tsx
+++ b/app/(auth)/sign-in/[[...sign-in]]/page.tsx
@@ -1,6 +1,7 @@
 import { SignIn, ClerkLoaded, ClerkLoading } from "@clerk/nextjs";
 import { Loader2 } from "lucide-react";
 import Image from "next/image";
+import { Card, CardContent } from "@/components/ui/card";
 
 const SignInPage = () => {
   return (
@@ -14,18 +15,22 @@ const SignInPage = () => {
         </div>
 
         <div className="mt-8 flex items-center justify-center">
-          <ClerkLoaded>
-            <SignIn path="/sign-in" />
-          </ClerkLoaded>
+          <Card className="w-full max-w-md">
+            <CardContent className="pt-6">
+              <ClerkLoaded>
+                <SignIn path="/sign-in" />
+              </ClerkLoaded>
 
-          <ClerkLoading>
-            <Loader2 className="animate-spin text-muted-foreground" />
-          </ClerkLoading>
+              <ClerkLoading>
+                <Loader2 className="animate-spin text-muted-foreground" />
+              </ClerkLoading>
+            </CardContent>
+          </Card>
         </div>
       </div>
 
       <div className="hidden h-full items-center justify-center bg-blue-600 lg:flex">
-        <Image src="/logo.svg" alt="Finance logo" height={100} width={100} />
+        <Image src="/logo.svg" alt="Business logo" height={100} width={100} />
       </div>
     </div>
   );

--- a/app/(auth)/sign-up/[[...sign-up]]/page.tsx
+++ b/app/(auth)/sign-up/[[...sign-up]]/page.tsx
@@ -1,6 +1,7 @@
 import { SignUp, ClerkLoaded, ClerkLoading } from "@clerk/nextjs";
 import { Loader2 } from "lucide-react";
 import Image from "next/image";
+import { Card, CardContent } from "@/components/ui/card";
 
 const SignUpPage = () => {
   return (
@@ -14,18 +15,22 @@ const SignUpPage = () => {
         </div>
 
         <div className="mt-8 flex items-center justify-center">
-          <ClerkLoaded>
-            <SignUp path="/sign-up" />
-          </ClerkLoaded>
+          <Card className="w-full max-w-md">
+            <CardContent className="pt-6">
+              <ClerkLoaded>
+                <SignUp path="/sign-up" />
+              </ClerkLoaded>
 
-          <ClerkLoading>
-            <Loader2 className="animate-spin text-muted-foreground" />
-          </ClerkLoading>
+              <ClerkLoading>
+                <Loader2 className="animate-spin text-muted-foreground" />
+              </ClerkLoading>
+            </CardContent>
+          </Card>
         </div>
       </div>
 
       <div className="hidden h-full items-center justify-center bg-blue-600 lg:flex">
-        <Image src="/logo.svg" alt="Finance logo" height={100} width={100} />
+        <Image src="/logo.svg" alt="Business logo" height={100} width={100} />
       </div>
     </div>
   );

--- a/components/header-logo.tsx
+++ b/components/header-logo.tsx
@@ -10,7 +10,7 @@ export const HeaderLogo = () => {
   return (
     <Link href="/">
       <div className="hidden items-center lg:flex">
-        <p className="ml-2.5 text-2xl capitalize font-semibold text-white">{orgName} Finance</p>
+        <p className="ml-2.5 text-2xl capitalize font-semibold text-white">{orgName} Business</p>
       </div>
     </Link>
   );

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -9,7 +9,7 @@ import { OrganizationSwitcher } from '@clerk/nextjs'
 
 export const Header = () => {
   return (
-    <header className="bg-gradient-to-b from-blue-700 to-blue-500 px-4 py-8 lg:px-14 lg:pb-32">
+    <header className="bg-gradient-to-b from-primary to-primary/80 px-4 py-8 lg:px-14 lg:pb-32">
       <div className="mx-auto max-w-screen-2xl">
         <div className="mb-14 flex w-full items-center justify-between">
           <div className="flex items-center lg:gap-x-16">

--- a/components/welcome-msg.tsx
+++ b/components/welcome-msg.tsx
@@ -12,7 +12,7 @@ export const WelcomeMsg = () => {
         {user?.username} 👋
       </h2>
       <p className="text-sm text-[#89B6FD] lg:text-base">
-        Ini adalah ringkasan laporan keuangan Anda.
+        Ini adalah ringkasan laporan bisnis Anda.
       </p>
     </div>
   );

--- a/config/index.ts
+++ b/config/index.ts
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
 
 export const siteConfig: Metadata = {
-  title: "Finance",
-  description: "Lacak pemasukan dan pengeluaran Anda dengan Finance.",
+  title: "Business Dashboard",
+  description: "Lacak pemasukan dan pengeluaran Anda dengan Business Dashboard.",
   keywords: [
     "reactjs",
     "nextjs",
@@ -15,7 +15,7 @@ export const siteConfig: Metadata = {
     "radix-ui",
     "cn",
     "clsx",
-    "finance-app",
+    "business-dashboard",
     "transactions",
     "dashboard",
     "accounts",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "email": "sanidhya.verma12345@gmail.com",
     "url": "https://github.com/sanidhyy"
   },
-  "description": "Lacak pemasukan dan pengeluaran Anda dengan Finance.",
+  "description": "Lacak pemasukan dan pengeluaran Anda dengan Business Dashboard.",
   "keywords": [
     "reactjs",
     "nextjs",


### PR DESCRIPTION
## Summary
- replace Finance branding with Business Dashboard branding
- style header with shadcn theme colors
- wrap auth pages in shadcn Card components

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687cedd4f0f4832ea00e73efc4d4c6c6