### PR TITLE
Update theme colors to black, white, and gold

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,64 +5,64 @@
 @layer base {
   :root {
     --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+    --foreground: 0 0% 0%;
 
     --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
+    --card-foreground: 0 0% 0%;
 
     --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
+    --popover-foreground: 0 0% 0%;
 
-    --primary: 222.2 47.4% 11.2%;
-    --primary-foreground: 210 40% 98%;
+    --primary: 50.6 100% 50%;
+    --primary-foreground: 0 0% 0%;
 
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 0 0% 100%;
+    --secondary-foreground: 0 0% 0%;
 
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
+    --muted: 0 0% 96%;
+    --muted-foreground: 0 0% 40%;
 
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
+    --accent: 50.6 100% 50%;
+    --accent-foreground: 0 0% 0%;
 
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
+    --destructive: 0 0% 0%;
+    --destructive-foreground: 0 0% 100%;
 
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 222.2 84% 4.9%;
+    --border: 0 0% 90%;
+    --input: 0 0% 90%;
+    --ring: 50.6 100% 50%;
 
     --radius: 0.5rem;
   }
 
   .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
+    --background: 0 0% 0%;
+    --foreground: 0 0% 100%;
 
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
+    --card: 0 0% 0%;
+    --card-foreground: 0 0% 100%;
 
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
+    --popover: 0 0% 0%;
+    --popover-foreground: 0 0% 100%;
 
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
+    --primary: 50.6 100% 50%;
+    --primary-foreground: 0 0% 0%;
 
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
+    --secondary: 0 0% 0%;
+    --secondary-foreground: 0 0% 100%;
 
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
+    --muted: 0 0% 0%;
+    --muted-foreground: 0 0% 60%;
 
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
+    --accent: 50.6 100% 50%;
+    --accent-foreground: 0 0% 0%;
 
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
+    --destructive: 0 0% 100%;
+    --destructive-foreground: 0 0% 0%;
 
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
+    --border: 0 0% 20%;
+    --input: 0 0% 20%;
+    --ring: 50.6 100% 50%;
   }
 }
 

--- a/components/area-variant.tsx
+++ b/components/area-variant.tsx
@@ -25,13 +25,13 @@ export const AreaVariant = ({ data }: AreaVariantProps) => {
         <CartesianGrid strokeDasharray="3 3" />
         <defs>
           <linearGradient id="income" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="2%" stopColor="#3d82f6" stopOpacity={0.8} />
-            <stop offset="98%" stopColor="#3d82f6" stopOpacity={0} />
+            <stop offset="2%" stopColor="#FFD700" stopOpacity={0.8} />
+            <stop offset="98%" stopColor="#FFD700" stopOpacity={0} />
           </linearGradient>
 
           <linearGradient id="expenses" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="2%" stopColor="#f43f5e" stopOpacity={0.8} />
-            <stop offset="98%" stopColor="#f43f5e" stopOpacity={0} />
+            <stop offset="2%" stopColor="#ffffff" stopOpacity={0.8} />
+            <stop offset="98%" stopColor="#ffffff" stopOpacity={0} />
           </linearGradient>
         </defs>
 
@@ -57,7 +57,7 @@ export const AreaVariant = ({ data }: AreaVariantProps) => {
           dataKey="income"
           stackId="income"
           strokeWidth={2}
-          stroke="#3d82f6"
+          stroke="#FFD700"
           fill="url(#income)"
           className="drop-shadow-sm"
         />
@@ -67,7 +67,7 @@ export const AreaVariant = ({ data }: AreaVariantProps) => {
           dataKey="expenses"
           stackId="expenses"
           strokeWidth={2}
-          stroke="#f43f5e"
+          stroke="#ffffff"
           fill="url(#expenses)"
           className="drop-shadow-sm"
         />

--- a/components/bar-variant.tsx
+++ b/components/bar-variant.tsx
@@ -41,8 +41,8 @@ export const BarVariant = ({ data }: BarVariantProps) => {
           )}
         />
 
-        <Bar dataKey="income" fill="#3d82f6" className="drop-shadow-sm" />
-        <Bar dataKey="expenses" fill="#f43f5e" className="drop-shadow-sm" />
+        <Bar dataKey="income" fill="#FFD700" className="drop-shadow-sm" />
+        <Bar dataKey="expenses" fill="#ffffff" className="drop-shadow-sm" />
       </BarChart>
     </ResponsiveContainer>
   );

--- a/components/category-tooltip.tsx
+++ b/components/category-tooltip.tsx
@@ -29,7 +29,7 @@ export const CategoryTooltip = ({ active, payload }: CategoryTooltipProps) => {
       <div className="space-y-1 p-2 px-3">
         <div className="flex items-center justify-between gap-x-4">
           <div className="flex items-center gap-x-2">
-            <div className="size-1.5 rounded-full bg-rose-500" aria-hidden />
+            <div className="size-1.5 rounded-full bg-white" aria-hidden />
 
             <p className="text-sm text-muted-foreground">Expenses</p>
           </div>

--- a/components/custom-tooltip.tsx
+++ b/components/custom-tooltip.tsx
@@ -31,7 +31,7 @@ export const CustomTooltip = ({ active, payload }: CustomTooltipProps) => {
       <div className="space-y-1 p-2 px-3">
         <div className="flex items-center justify-between gap-x-4">
           <div className="flex items-center gap-x-2">
-            <div className="size-1.5 rounded-full bg-blue-500" aria-hidden />
+            <div className="size-1.5 rounded-full bg-[#FFD700]" aria-hidden />
 
             <p className="text-sm text-muted-foreground">Income</p>
           </div>
@@ -43,7 +43,7 @@ export const CustomTooltip = ({ active, payload }: CustomTooltipProps) => {
 
         <div className="flex items-center justify-between gap-x-4">
           <div className="flex items-center gap-x-2">
-            <div className="size-1.5 rounded-full bg-rose-500" aria-hidden />
+            <div className="size-1.5 rounded-full bg-white" aria-hidden />
 
             <p className="text-sm text-muted-foreground">Expenses</p>
           </div>

--- a/components/line-variant.tsx
+++ b/components/line-variant.tsx
@@ -44,14 +44,14 @@ export const LineVariant = ({ data }: LineVariantProps) => {
         <Line
           dot={false}
           dataKey="income"
-          stroke="#3d82f6"
+          stroke="#FFD700"
           strokeWidth={2}
           className="drop-shadow-sm"
         />
         <Line
           dot={false}
           dataKey="expenses"
-          stroke="#f43f5e"
+          stroke="#ffffff"
           strokeWidth={2}
           className="drop-shadow-sm"
         />

--- a/components/pie-variant.tsx
+++ b/components/pie-variant.tsx
@@ -11,7 +11,7 @@ import { formatPercentage } from "@/lib/utils";
 
 import { CategoryTooltip } from "./category-tooltip";
 
-const COLORS = ["#0062FF", "#12C6FF", "#FF647F", "#FF9354"];
+const COLORS = ["#FFD700", "#ffffff", "#000000", "#FFD700"];
 
 type PieVariantProps = {
   data: {

--- a/components/radar-variant.tsx
+++ b/components/radar-variant.tsx
@@ -23,8 +23,8 @@ export const RadarVariant = ({ data }: RadarVariantProps) => {
         <PolarRadiusAxis style={{ fontSize: "12px" }} />
         <Radar
           dataKey="value"
-          stroke="#3d82f6"
-          fill="#3d82f6"
+          stroke="#FFD700"
+          fill="#FFD700"
           fillOpacity={0.6}
         />
       </RadarChart>

--- a/components/radial-variant.tsx
+++ b/components/radial-variant.tsx
@@ -7,7 +7,7 @@ import {
 
 import { formatCurrency } from "@/lib/utils";
 
-const COLORS = ["#0062FF", "#12C6FF", "#FF647F", "#FF9354"];
+const COLORS = ["#FFD700", "#ffffff", "#000000", "#FFD700"];
 
 type RadialVariantProps = {
   data: {


### PR DESCRIPTION
## Summary
- adjust global theme variables to black/white/gold palette
- update chart color schemes to match new theme
- tweak tooltip indicators to use new colors

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687cf6815858832ea0c626a29d5e7def